### PR TITLE
Bower install failure: ENOTFOUND Package 0 not found

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,8 @@
   "name": "backbone.api.facebook",
   "version": "0.6.0",
   "main": ["./backbone.api.facebook.js"],
-  "dependencies": [ "backbone", "underscore" ]
+  "dependencies": {
+    "backbone" : "*",
+    "underscore" : "*"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone.api.facebook",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": ["./backbone.api.facebook.js"],
   "dependencies": {
     "backbone" : "*",


### PR DESCRIPTION
Badly formatted "dependencies" section of bower.json is attempting to install a package named "0". This section should be an object hash, as described [here](http://bower.io/#defining-a-package).
